### PR TITLE
SVC-16496: Setup gsi-sshd

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![pdk-validate](https://github.com/ncsa/puppet-profile_gsi_ssh/workflows/pdk-validate/badge.svg)
 ![yamllint](https://github.com/ncsa/puppet-profile_gsi_ssh/workflows/yamllint/badge.svg)
 
-NCSA Common Puppet Profiles - configure GitLab service
+NCSA Common Puppet Profiles - install and configure GSI-SSH
 
 ## Table of Contents
 
@@ -19,27 +19,59 @@ NCSA Common Puppet Profiles - configure GitLab service
 This puppet profile installs and configures GSI OpenSSH.
 
 See the following references for GSI OpenSSH:
-- https://opensciencegrid.org/docs/other/gsissh/
 - https://gridcf.org/gct-docs/latest/gsiopenssh/
-- https://software.xsede.org/production/gsi-openssh-server/latest/XSEDE-GSI-OpenSSH-install.html
-- http://grid.ncsa.illinois.edu/ssh/admin.html
+- https://software.xsede.org/production/gsi-openssh-server/versionless/XSEDE-GSI-OpenSSH-install.html
+- https://opensciencegrid.org/docs/other/gsissh/
 
 ## Setup
 
+### GSI-OpenSSHd Service
+
 Include profile_gsi_ssh in a puppet profile file:
 ```
-include ::profile_gsi_ssh
+include ::profile_gsi_ssh::server
+```
+
+A few parameters must be set, e.g. via hiera or vault:
+```yaml
+profile_gsi_ssh::server::allow_groups:
+  - "project_active_users"
+profile_gsi_ssh::server::deny_groups:
+  - "all_disabled_usr"
+  - "project_denied_users"
+profile_gsi_ssh::server::cert::hostcert: |
+  -----BEGIN CERTIFICATE----- 
+  ...
+  -----END CERTIFICATE----- 
+profile_gsi_ssh::server::cert::hostkey: |
+  -----BEGIN RSA PRIVATE KEY-----
+  ...
+  -----END RSA PRIVATE KEY-----
+```
+
+### GSI-OpenSSH Client
+
+Optionally you can just include the GSI-OpenSSH client:
+```
+include ::profile_gsi_ssh::client
 ```
 
 
 ## Usage
 
-The goal is that no paramters are required to be set. The default paramters should work for most NCSA deployments out of the box.
+For GSI-OpenSSH Server usage, a few parameters noted above will need to be set.
+
+### grid-mapfile Scripts
+
+You will need to customize the `profile_gsi_ssh::server::gridmap::crons` & `profile_gsi_ssh::server::gridmap::files` parameters to fit with how you need to sync in the `/etc/grid-security/grid-mapfile`. Sample scripts and a cron are included, but at a minimum will need to be updated to match where you need to sync your `grid-mapfile`(s) from.
 
 
 ## Dependencies
 
+- [herculesteam/augeasproviders](https://forge.puppet.com/herculesteam/augeasproviders)
+- [ncsa/profile_monitoring](https://github.com/ncsa/puppet-profile_monitoring) - for optional telegraf monitoring of ssl hostkey
 - [ncsa/sshd](https://github.com/ncsa/puppet-sshd)
+- [puppet/epel](https://forge.puppet.com/modules/puppet/epel)
 
 
 ## Reference

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,6 +9,8 @@
 * [`profile_gsi_ssh`](#profile_gsi_ssh): Install and configure GSI OpenSSH client and/or server
 * [`profile_gsi_ssh::client`](#profile_gsi_sshclient): Install and configure GSI OpenSSH client
 * [`profile_gsi_ssh::server`](#profile_gsi_sshserver): Install and configure GSI OpenSSH Server
+* [`profile_gsi_ssh::server::cert`](#profile_gsi_sshservercert): Manage the certificates for GSI-OpenSSH service
+* [`profile_gsi_ssh::server::gridmap`](#profile_gsi_sshservergridmap): Configure and manage gridmap file
 
 ## Classes
 
@@ -21,7 +23,7 @@ Install and configure GSI OpenSSH client and/or server
 ##### 
 
 ```puppet
-include profile_gsi_ssh
+include profile_gsi_ssh::server
 ```
 
 ### <a name="profile_gsi_sshclient"></a>`profile_gsi_ssh::client`
@@ -36,6 +38,18 @@ Install and configure GSI OpenSSH client
 include profile_gsi_ssh::client
 ```
 
+#### Parameters
+
+The following parameters are available in the `profile_gsi_ssh::client` class:
+
+* [`required_packages`](#required_packages)
+
+##### <a name="required_packages"></a>`required_packages`
+
+Data type: `Array[String]`
+
+List of package names to be installed (OS specific).
+
 ### <a name="profile_gsi_sshserver"></a>`profile_gsi_ssh::server`
 
 Install and configure GSI OpenSSH Server
@@ -47,4 +61,217 @@ Install and configure GSI OpenSSH Server
 ```puppet
 include profile_gsi_ssh::server
 ```
+
+#### Parameters
+
+The following parameters are available in the `profile_gsi_ssh::server` class:
+
+* [`allow_groups`](#allow_groups)
+* [`config`](#config)
+* [`config_file`](#config_file)
+* [`deny_groups`](#deny_groups)
+* [`disable_service_name`](#disable_service_name)
+* [`files`](#files)
+* [`manage_service`](#manage_service)
+* [`port`](#port)
+* [`required_packages`](#required_packages)
+* [`service_name`](#service_name)
+* [`subnets`](#subnets)
+* [`disabled_service_name`](#disabled_service_name)
+
+##### <a name="allow_groups"></a>`allow_groups`
+
+Data type: `Array[String]`
+
+List of groups allowed access via GSI OpenSSH server
+
+##### <a name="config"></a>`config`
+
+Data type: `Hash`
+
+Hash of global config settings
+Defaults provided by this module
+Values from multiple sources are merged
+Key collisions are resolved in favor of the higher priority value
+
+##### <a name="config_file"></a>`config_file`
+
+Data type: `String`
+
+Full path to sshd_config file
+
+##### <a name="deny_groups"></a>`deny_groups`
+
+Data type: `Array[String]`
+
+List of groups denied access via GSI OpenSSH server
+
+##### <a name="disable_service_name"></a>`disable_service_name`
+
+Name of default sshd service to disable
+
+##### <a name="files"></a>`files`
+
+Data type: `Hash`
+
+File resources for setting up files
+
+##### <a name="manage_service"></a>`manage_service`
+
+Data type: `Boolean`
+
+Flag of whether to manage sshd service
+
+##### <a name="port"></a>`port`
+
+Data type: `String`
+
+TCP port that GSI OpenSSH server listens on
+
+##### <a name="required_packages"></a>`required_packages`
+
+Data type: `Array[String]`
+
+List of package names to be installed (OS specific).
+
+##### <a name="service_name"></a>`service_name`
+
+Data type: `String`
+
+Name of gsi-sshd service
+
+##### <a name="subnets"></a>`subnets`
+
+Data type: `Array[String]`
+
+List of network subnets allowed access via GSI OpenSSH server
+
+##### <a name="disabled_service_name"></a>`disabled_service_name`
+
+Data type: `String`
+
+
+
+### <a name="profile_gsi_sshservercert"></a>`profile_gsi_ssh::server::cert`
+
+Manage the certificates for GSI-OpenSSH service
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_gsi_ssh::server::cert
+```
+
+#### Parameters
+
+The following parameters are available in the `profile_gsi_ssh::server::cert` class:
+
+* [`files`](#files)
+* [`hostcert`](#hostcert)
+* [`hostcert_path`](#hostcert_path)
+* [`hostkey`](#hostkey)
+* [`hostkey_path`](#hostkey_path)
+* [`monitor`](#monitor)
+* [`monitor_file_content`](#monitor_file_content)
+* [`monitor_file_path`](#monitor_file_path)
+* [`monitor_interval`](#monitor_interval)
+* [`required_packages`](#required_packages)
+
+##### <a name="files"></a>`files`
+
+Data type: `Hash`
+
+File resources for setting up files
+
+##### <a name="hostcert"></a>`hostcert`
+
+Data type: `String`
+
+Host IGTF Server certificate file contents
+
+##### <a name="hostcert_path"></a>`hostcert_path`
+
+Data type: `String`
+
+Full path to host IGTF Server certificate file
+
+##### <a name="hostkey"></a>`hostkey`
+
+Data type: `String`
+
+Host IGTF Server private key file contents
+
+##### <a name="hostkey_path"></a>`hostkey_path`
+
+Data type: `String`
+
+Full path to host IGTF Server private key file
+
+##### <a name="monitor"></a>`monitor`
+
+Data type: `Boolean`
+
+Whether to monitor the hostcert for validity with Telegraf
+
+##### <a name="monitor_file_content"></a>`monitor_file_content`
+
+Data type: `String`
+
+Content of telegraf input file template
+
+##### <a name="monitor_file_path"></a>`monitor_file_path`
+
+Data type: `String`
+
+Full path to telegraf input file template
+
+##### <a name="monitor_interval"></a>`monitor_interval`
+
+Data type: `String`
+
+Interval used by telegraf input
+
+##### <a name="required_packages"></a>`required_packages`
+
+Data type: `Array[String]`
+
+List of package names to be installed (OS specific).
+
+### <a name="profile_gsi_sshservergridmap"></a>`profile_gsi_ssh::server::gridmap`
+
+Generally speaking some files and/or cron scripts will need to be put in place for
+grid map and voms authentication.
+This class lets various custom files and cron entries be setup via hiera parameters
+for this purpose.
+
+See: https://opensciencegrid.org/docs/security/lcmaps-voms-authentication/#configuring-the-lcmaps-voms-plugin
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_gsi_ssh::server::gridmap
+```
+
+#### Parameters
+
+The following parameters are available in the `profile_gsi_ssh::server::gridmap` class:
+
+* [`crons`](#crons)
+* [`files`](#files)
+
+##### <a name="crons"></a>`crons`
+
+Data type: `Hash`
+
+Cron resources for setting up gridmap files
+
+##### <a name="files"></a>`files`
+
+Data type: `Hash`
+
+File resources for setting up gridmap files
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,1 +1,74 @@
---- {}
+---
+profile_gsi_ssh::server::cert::files: {}
+profile_gsi_ssh::server::cert::hostcert: ""  # PROVIDE CONTENTS OF HOST IGTF CERTIFICATE
+profile_gsi_ssh::server::cert::hostkey: ""   # PROVIDE CONTENTS OF HOST PRIVATE KEY
+profile_gsi_ssh::server::cert::monitor: true
+profile_gsi_ssh::server::cert::monitor_file_content: |
+  [[inputs.x509_cert]]
+    sources = [
+    ]
+    interval = "3h"
+profile_gsi_ssh::server::cert::monitor_file_path: "/etc/telegraf/telegraf.d/sslcert-check.conf"
+profile_gsi_ssh::server::cert::monitor_interval: "3h"
+
+profile_gsi_ssh::server::allow_groups: []
+
+profile_gsi_ssh::server::config:
+  AllowGroups: "root"
+  AuthenticationMethods: "none"
+  PermitRootLogin: "no"
+
+profile_gsi_ssh::server::config_file: "/etc/gsissh/sshd_config"
+
+profile_gsi_ssh::server::deny_groups:
+  - "all_disabled_usr"
+
+profile_gsi_ssh::server::disabled_service_name: ""
+
+# EXAMPLE CRON
+profile_gsi_ssh::server::gridmap::crons:
+  "SYNC grid-mapfile FOR GSI OPENSSH":
+    command: "/root/cron_scripts/grid-mapfile_stage.sh && /root/cron_scripts/grid-mapfile_sync.sh"
+    minute: "*/20"
+# EXAMPLE SCRIPT FILES
+profile_gsi_ssh::server::gridmap::files:
+  "/root/cron_scripts/grid-mapfile_stage.sh":
+    content: |
+      #! /bin/bash
+      # This file is managed by Puppet - Changes may be overwritten
+      set -e
+      SRCFILES="/project/home/sw/admin/grid-security/grid*mapfile*"
+      DESTFILE="/etc/grid-security/grid-mapfile.stage"
+      # FILTER RECORDS WITHOUT DOUBLE QUOTES, SORT BY MAPPED USERNAME AT END OF LINE
+      cat ${SRCFILES} | grep '\"' | awk '{print $NF,$0}' | sort | cut -f2- -d' ' | uniq > ${DESTFILE}
+    mode: "0700"
+  "/root/cron_scripts/grid-mapfile_sync.sh":
+    content: |
+      #! /bin/bash
+      # This file is managed by Puppet - Changes may be overwritten
+      set -e
+      SRCFILE="/etc/grid-security/grid-mapfile.stage"
+      DESTFILE="/etc/grid-security/grid-mapfile"
+      SIZE_DIFF="2/3"
+      if ! diff ${SRCFILE} ${DESTFILE} >/dev/null 2>&1 ; then
+        if [ -f "${DESTFILE}" ]; then
+          # ONLY COPY IF SRCFILE IS >= 2/3 of DESTFILE SIZE
+          MINSIZE=$(bc <<< "$(stat --printf=%s ${DESTFILE})*${SIZE_DIFF}")
+          rsync -q --min-size=${MINSIZE} ${SRCFILE} ${DESTFILE}
+        else
+          rsync -q ${SRCFILE} ${DESTFILE}
+        fi
+      fi
+      chmod 0444 ${DESTFILE}
+      if ! diff ${SRCFILE} ${DESTFILE} >/dev/null 2>&1 ; then
+        echo "Error: The files did not sync:"
+        ls -lh ${SRCFILE}
+        ls -lh ${DESTFILE}
+      fi
+    mode: "0700"
+
+profile_gsi_ssh::server::port: "222"
+
+profile_gsi_ssh::server::subnets:
+  - "0.0.0.0/1"  # Bottom half of all IPv4
+  - "128.0.0.0/1"  # Top half of all IPv4

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,1 +1,35 @@
---- {}
+---
+profile_gsi_ssh::client::required_packages:
+  - "globus-proxy-utils"
+  - "gsi-openssh-clients"
+
+profile_gsi_ssh::server::files:
+  "/etc/gsissh/ssh_host_ecdsa_key":
+    ensure: "link"
+    target: "/etc/ssh/ssh_host_ecdsa_key"
+  "/etc/gsissh/ssh_host_ecdsa_key.pub":
+    ensure: "link"
+    target: "/etc/ssh/ssh_host_ecdsa_key.pub"
+  "/etc/gsissh/ssh_host_ed25519_key":
+    ensure: "link"
+    target: "/etc/ssh/ssh_host_ed25519_key"
+  "/etc/gsissh/ssh_host_ed25519_key.pub":
+    ensure: "link"
+    target: "/etc/ssh/ssh_host_ed25519_key.pub"
+  "/etc/gsissh/ssh_host_rsa_key":
+    ensure: "link"
+    target: "/etc/ssh/ssh_host_rsa_key"
+  "/etc/gsissh/ssh_host_rsa_key.pub":
+    ensure: "link"
+    target: "/etc/ssh/ssh_host_rsa_key.pub"
+profile_gsi_ssh::server::manage_service: true
+profile_gsi_ssh::server::required_packages:
+  - "gsi-openssh-server"
+  #- "gsi-openssh-server-xsede"
+profile_gsi_ssh::server::service_name: "gsisshd"
+
+profile_gsi_ssh::server::cert::hostcert_path: "/etc/grid-security/hostcert.pem"
+profile_gsi_ssh::server::cert::hostkey_path: "/etc/grid-security/hostkey.pem"
+profile_gsi_ssh::server::cert::required_packages:
+  #- "osg-ca-certs"
+  - "xsede-ca-certificates"

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,7 +1,15 @@
 # @summary Install and configure GSI OpenSSH client
 #
+# @param required_packages
+#   List of package names to be installed (OS specific).
+#
 # @example
 #   include profile_gsi_ssh::client
-class profile_gsi_ssh::client {
+class profile_gsi_ssh::client (
+  Array[String]     $required_packages,   #per OS
+) {
+
+  # PACKAGES
+  ensure_packages( $required_packages, {'ensure' => 'present'} )
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 # @summary Install and configure GSI OpenSSH client and/or server
 #
 # @example
-#   include profile_gsi_ssh
+#   include profile_gsi_ssh::server
 class profile_gsi_ssh {
 
   # You will want to directly include one of the following:

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,17 +1,234 @@
 # @summary Install and configure GSI OpenSSH Server
 #
+# @param allow_groups
+#   List of groups allowed access via GSI OpenSSH server
+#
+# @param config
+#   Hash of global config settings
+#   Defaults provided by this module
+#   Values from multiple sources are merged
+#   Key collisions are resolved in favor of the higher priority value
+#
+# @param config_file
+#   Full path to sshd_config file
+#
+# @param deny_groups
+#   List of groups denied access via GSI OpenSSH server
+#
+# @param disable_service_name
+#   Name of default sshd service to disable
+#
+# @param files
+#   File resources for setting up files
+#
+# @param manage_service
+#   Flag of whether to manage sshd service
+#
+# @param port
+#   TCP port that GSI OpenSSH server listens on
+#
+# @param required_packages
+#   List of package names to be installed (OS specific).
+#
+# @param service_name
+#   Name of gsi-sshd service
+#
+# @param subnets
+#   List of network subnets allowed access via GSI OpenSSH server
+#
 # @example
 #   include profile_gsi_ssh::server
-class profile_gsi_ssh::server {
+class profile_gsi_ssh::server (
+  Array[String] $allow_groups,
+  Hash          $config,
+  String        $config_file,
+  Array[String] $deny_groups,
+  String        $disabled_service_name,
+  Hash          $files,
+  Boolean       $manage_service,
+  String        $port,
+  Array[String] $required_packages,
+  String        $service_name,
+  Array[String] $subnets,
+) {
 
   include ::profile_gsi_ssh::client
+  include ::profile_gsi_ssh::server::cert
+  include ::profile_gsi_ssh::server::gridmap
 
-  ## NEED TO IMPLEMENT THE FOLLOWING
-  # configuration for gsissh
-  # install additional packages
-  # alternate sshd service
-  # build gridmap files, etc
-  # alternate sshd_config authentication settings
-  # obtaining a host certificate
+  # PACKAGES
+  ensure_packages( $required_packages, {'ensure' => 'present'} )
+
+  $file_defaults = {
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+  }
+  ensure_resources('file', $files, $file_defaults )
+
+  if ( ! empty($disabled_service_name) ) {
+    service { $disabled_service_name :
+      ensure     => stopped,
+      enable     => false,
+      hasstatus  => true,
+      hasrestart => true,
+    }
+  }
+  if ( $manage_service ) {
+    service { $service_name :
+      ensure     => running,
+      enable     => true,
+      hasstatus  => true,
+      hasrestart => true,
+      require    => [
+        Package[ $required_packages ],
+      ],
+    }
+    # SET DEFAULTS TO NOTIFY SERVICE
+    $config_defaults = {
+      'notify' => Service[$service_name] ,
+      'target' => $config_file,
+    }
+  } else {
+    # SET DEFAULTS TO SKIP NOTIFY SERVICE
+    # THE ENSURE => PRESENT IS A DEFAULT, BUT SETTING IT SO THAT WE CAN SET SOME DEFAULT
+    $config_defaults = {
+      'ensure' => present,
+      'target' => $config_file,
+    }
+  }
+
+  # CONFIGURE gsissh sshd_config FILE
+
+  $puppet_file_header = '# This file is managed by Puppet - Changes may be overwritten'
+  exec { "add puppet header to ${config_file}":
+    command => "sed -i '1s/^/${puppet_file_header}\\n/' '${config_file}'",
+    unless  => "grep '${puppet_file_header}' ${config_file}",
+    path    => [ '/bin', '/usr/bin' ],
+  }
+  # CONFIGURE PORT
+  sshd_config {
+    'GSI Port' :
+      key   => 'Port',
+      value => $port,
+    ;
+    default:
+      * => $config_defaults,
+    ;
+  }
+  # ADD DENY GROUPS
+  sshd_config {
+    'GSI DenyGroups' :
+      key   => 'DenyGroups',
+      value => $deny_groups,
+    ;
+    default:
+      * => $config_defaults,
+    ;
+  }
+  # APPLY MISC sshd_config SETTINGS
+  $config.each | $key, $val | {
+    sshd_config {
+      "GSI ${key}" :
+        key   => $key,
+        value => $val,
+      ;
+      default:
+        * => $config_defaults,
+      ;
+    }
+  }
+
+  # Setup Match Block
+  # Logic borrowed from https://github.com/ncsa/puppet-sshd/blob/3a27bd52e01f5484605e6e45297b0cc646f1c979/manifests/allow_from.pp#L127
+  $config_match_defaults = $config_defaults + {
+    'position' => 'before first match'
+  }
+  $additional_match_params = {
+    'AuthenticationMethods' => 'gssapi-with-mic',
+  }
+  $group_params = $allow_groups ? {
+    Array[ String, 1 ] => { 'AllowGroups' => $allow_groups },
+    default            => {}
+  }
+  # Combine all cfg_match_params into a single hash
+  $cfg_match_params = $additional_match_params + $group_params
+  #$cfg_match_params = $group_params
+
+  # Create Host and/or Address match criteria
+  # Hostnames require "Match Host"
+  # IPs/CIDRs require "Match Address"
+  # Create separate lists and make two separate match blocks in sshd_config
+  # Criteria will be either "Host" or "Address"
+  # Pattern will be the CSV string of hostnames or IPs
+  # See also: "sshd_config" man page, for details of "criteria-pattern pairs"
+  $name_list = $subnets.filter | $elem | { $elem =~ /[a-zA-Z]/ }
+  $ip_list   = $subnets.filter | $elem | { $elem !~ /[a-zA-Z]/ }
+  #associate the correct criteria with each list, filter empty lists
+  $host_data = {
+    'Host'    => $name_list,
+    'Address' => $ip_list,
+  }.filter | $criteria, $list | {
+    size( $list ) > 0
+  }
+
+  # WE DO NOT CURRENTLY SUPPORT LISTS OF USERS
+  #$users = []
+  ## Create User match criteria (empty if user list is empty)
+  #$user_csv = $users ? {
+  #  Array[ String, 1 ] => join( $users, ',' ),
+  #  default            => '',
+  #}
+  #$user_criteria = $user_csv ? {
+  #  String[1] => "User ${user_csv}",
+  #  default   => '',
+  #}
+  # Create Group match criteria (empty if group list is empty)
+  $group_csv = $allow_groups ? {
+    Array[ String, 1 ] => join( $allow_groups, ',' ),
+    default            => '',
+  }
+  $group_criteria = $group_csv ? {
+    String[1] => "Group ${group_csv}",
+    default   => '',
+  }
+
+  #loop through host_data creating a match block for each criteria-pattern
+  $host_data.each | $criteria, $list | {
+    $pattern = join( $list, ',' )
+    #$match_condition = "${criteria} ${pattern} ${user_criteria} ${group_criteria}"
+    # SPECIFYING GROUPS IN MATCH BREAKS ACCESS FOR USERS WHOSE REMOTE USERNAMES DIFFER FROM MAPPED USERNAME
+    #$match_condition = "${criteria} ${pattern} ${group_criteria}"
+    $match_condition = "${criteria} ${pattern}"
+
+    #ensure match block exists
+    ensure_resource( 'sshd_config_match', $match_condition, $config_match_defaults )
+
+    #add parameters to the match block
+    $config_data = $cfg_match_params.reduce( {} ) | $memo, $kv | {
+      $key = $kv[0]
+      $val = $kv[1]
+      $memo + {
+        "${match_condition} ${key}" => {
+          'key'       => $key,
+          'value'     => $val,
+          'condition' => $match_condition,
+        }
+      }
+    }
+    ensure_resources( 'sshd_config', $config_data, $config_defaults )
+  }
+
+
+  ### FIREWALL
+  $subnets.each | $subnet | {
+    firewall { "222 allow GSI-SSH on ${port} from ${subnet}":
+      dport  => $port,
+      proto  => tcp,
+      source => $subnet,
+      action => accept,
+    }
+  }
 
 }

--- a/manifests/server/cert.pp
+++ b/manifests/server/cert.pp
@@ -1,0 +1,108 @@
+# @summary Manage the certificates for GSI-OpenSSH service
+#
+# @param files
+#   File resources for setting up files
+#
+# @param hostcert
+#   Host IGTF Server certificate file contents
+#
+# @param hostcert_path
+#   Full path to host IGTF Server certificate file
+#
+# @param hostkey
+#   Host IGTF Server private key file contents
+#
+# @param hostkey_path
+#   Full path to host IGTF Server private key file
+#
+# @param monitor
+#   Whether to monitor the hostcert for validity with Telegraf
+#
+# @param monitor_file_content
+#   Content of telegraf input file template
+#
+# @param monitor_file_path
+#   Full path to telegraf input file template
+#
+# @param monitor_interval
+#   Interval used by telegraf input
+#
+# @param required_packages
+#   List of package names to be installed (OS specific).
+#
+# @example
+#   include profile_gsi_ssh::server::cert
+class profile_gsi_ssh::server::cert (
+  Hash          $files,
+  String        $hostcert,
+  String        $hostcert_path,
+  String        $hostkey,
+  String        $hostkey_path,
+  Boolean       $monitor,
+  String        $monitor_file_content,
+  String        $monitor_file_path,
+  String        $monitor_interval,
+  Array[String] $required_packages,
+) {
+
+  # PACKAGES
+  ensure_packages( $required_packages, {'ensure' => 'present'} )
+
+  if ( $profile_gsi_ssh::server::manage_service ) {
+    File {
+      notify  => Service[$profile_gsi_ssh::server::service_name],
+    }
+  }
+
+  $file_defaults = {
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+  }
+  ensure_resources('file', $files, $file_defaults )
+
+  file { $hostcert_path :
+    content => Sensitive($hostcert),
+    mode    => '0444',
+  }
+  file { $hostkey_path :
+    content => Sensitive($hostkey),
+    mode    => '0400',
+  }
+
+  if ( $monitor ) {
+    # SETUP A LOCAL TELEGRAF INPUT FILE FOR SSL CERT MONITORING
+    include profile_monitoring::telegraf
+    if ( $::profile_monitoring::telegraf::enabled )
+    {
+      file { $monitor_file_path :
+        content => $monitor_file_content,
+        group   => 'telegraf',
+        mode    => '0640',
+        owner   => 'root',
+        replace => false,
+        notify  => Service['telegraf'],
+      }
+      file_line { 'set sslcert-check interval':
+        ensure   => 'present',
+        after    => ']',
+        line     => "  interval = \"${monitor_interval}\"",
+        match    => 'interval',
+        multiple => 'false',
+        notify   => Service['telegraf'],
+        path     => $monitor_file_path,
+      }
+      file_line { "telegraf_sslcert_check for ${hostcert_path}":
+        ensure   => 'present',
+        after    => 'sources',
+        line     => "    \"file://${hostcert_path}\",",
+        match    => $hostcert_path,
+        multiple => 'false',
+        notify   => Service['telegraf'],
+        path     => $monitor_file_path,
+      }
+    }
+  }
+
+}

--- a/manifests/server/gridmap.pp
+++ b/manifests/server/gridmap.pp
@@ -1,0 +1,36 @@
+# @summary Configure and manage gridmap file
+# 
+# Generally speaking some files and/or cron scripts will need to be put in place for
+# grid map and voms authentication.
+# This class lets various custom files and cron entries be setup via hiera parameters
+# for this purpose.
+#
+# See: https://opensciencegrid.org/docs/security/lcmaps-voms-authentication/#configuring-the-lcmaps-voms-plugin
+#
+# @param crons
+#   Cron resources for setting up gridmap files
+#
+# @param files
+#   File resources for setting up gridmap files
+#
+# @example
+#   include profile_gsi_ssh::server::gridmap
+class profile_gsi_ssh::server::gridmap (
+  Hash $crons,
+  Hash $files,
+) {
+
+  $cron_defaults = {
+    ensure  => present,
+  }
+  ensure_resources('cron', $crons, $cron_defaults )
+
+  $file_defaults = {
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+  }
+  ensure_resources('file', $files, $file_defaults )
+
+}

--- a/spec/classes/server/cert_spec.rb
+++ b/spec/classes/server/cert_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_gsi_ssh::server::cert' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/server/gridmap_spec.rb
+++ b/spec/classes/server/gridmap_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_gsi_ssh::server::gridmap' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end


### PR DESCRIPTION
See: https://jira.ncsa.illinois.edu/browse/SVC-16496

This is the first release of this profile module.

By default this creates a 2nd SSHd service on port 222 that runs `gsisshd`. But there are lots of options in here so that it can run on other ports, including 22 and replace the default OpenSSH `sshd` if desired.

This is being tested on `dt-login03`.