### PR TITLE
SVC-16496: Fix gsi username mapping due to bad AuthenticationMethods

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -15,8 +15,15 @@ profile_gsi_ssh::server::allow_groups: []
 
 profile_gsi_ssh::server::config:
   AllowGroups: "root"
-  AuthenticationMethods: "none"
+  AuthenticationMethods: "gssapi-keyex gssapi-with-mic"
+  ChallengeResponseAuthentication: "no"
+  GSSAPIAuthentication: "yes"
+  GSSAPIDelegateCredentials: "no"
+  HostbasedAuthentication: "no"
+  KerberosAuthentication: "no"
+  PasswordAuthentication: "no"
   PermitRootLogin: "no"
+  PubkeyAuthentication: "no"
 
 profile_gsi_ssh::server::config_file: "/etc/gsissh/sshd_config"
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -146,7 +146,7 @@ class profile_gsi_ssh::server (
     'position' => 'before first match'
   }
   $additional_match_params = {
-    'AuthenticationMethods' => 'gssapi-with-mic',
+    'AuthenticationMethods' => 'gssapi-keyex gssapi-with-mic',
   }
   $group_params = $allow_groups ? {
     Array[ String, 1 ] => { 'AllowGroups' => $allow_groups },


### PR DESCRIPTION
Plus some additional hardening to limit non-gsi/gssapi authentication or caching for kex certificates locally.

This is being tested on `dt-login03`.